### PR TITLE
Make svgJar a callable method

### DIFF
--- a/app/helpers/svg-jar.js
+++ b/app/helpers/svg-jar.js
@@ -3,6 +3,8 @@ import makeHelper from 'ember-svg-jar/utils/make-helper';
 import makeSVG from 'ember-svg-jar/utils/make-svg';
 import inlineAssets from '../inline-assets';
 
-export default makeHelper((assetId, svgAttrs) => (
-  htmlSafe(makeSVG(assetId, svgAttrs, inlineAssets))
-));
+export function svgJar(assetId, svgAttrs) {
+  return htmlSafe(makeSVG(assetId, svgAttrs, inlineAssets));
+}
+
+export default makeHelper(svgJar);


### PR DESCRIPTION
+ Provide `svgJar` helper method outside of templates (i.e. in routes, components, controllers)
+ Attempts to resolve #14