### PR TITLE
Fix require path in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/index');
+module.exports = require('./src/index');


### PR DESCRIPTION
It turns out the only thing that was keeping `master` from working for me when I made the release request in my comment on #30 was that `index.js` is trying to refer to `lib/index` instead of `src/index`. Updating this file path gets `master` (including the option deprecation fix) working in my project.