### PR TITLE
Allow svg symbol to be placed into another location

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -77,6 +77,21 @@ let app = new EmberApp(defaults, {
 });
 ```
 
+#### [`symbol` strategy] change location of svgJar symbol object into a div IE:ember-testing-container
+
+```javascript
+let app = new EmberApp(defaults, {
+  svgJar: {
+    strategy: ['symbol'],
+
+    symbol: {
+      loaderLocationEnabled: true,
+      loaderLocation: 'ember-testing-container',
+    }
+  }
+});
+```
+
 #### Using both `symbol` and `inline` strategies at the same time:
 
 ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,9 @@ module.exports = {
 
     if (type === 'body' && includeLoader) {
       return symbolsLoaderScript
-        .replace('{{FILE_PATH}}', this.optionFor('symbol', 'outputFile'));
+        .replace('{{FILE_PATH}}', this.optionFor('symbol', 'outputFile'))
+        .replace('{{LOADER_LOCATION}}', this.optionFor('symbol', 'loaderLocation'))
+        .replace('{{LOADER_LOCATION_ENABLED}}', this.optionFor('symbol', 'loaderLocationEnabled'));
     }
 
     return '';

--- a/symbols-loader.html
+++ b/symbols-loader.html
@@ -5,6 +5,9 @@
   ajax.onload = function(e) {
     var div = document.createElement('div');
     div.innerHTML = ajax.responseText;
+    if ({{LOADER_LOCATION_ENABLED}}) {
+      return document.getElementById('{{LOADER_LOCATION}}').appendChild(div)
+    }
     document.body.insertBefore(div, document.body.childNodes[0]);
   };
 </script>


### PR DESCRIPTION
First thanks for a great project 

We are using a visual regressions in our tests and the embedded svgJar object is not included in output of test unless the svgJar symbol object is placed into the `#ember-testing-container`.  We are using [percy.io](https://percy.io/)

Is this something worth adding to this project?