### PR TITLE
Add rootURL option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,8 @@ All global options with their default values:
     sourceDirs: ['public'],
     stripPath: true,
     optimizer: {},
-    persist: true
+    persist: true,
+    rootURL: '/'
   }
 }
 ```
@@ -122,6 +123,25 @@ Type: `Boolean`
 Default: `true`
 
 Enable or disable a persistent cache to improve build performance across restarts. Check out [broccoli-persistent-filter](https://github.com/stefanpenner/broccoli-persistent-filter) for more details.
+
+#### rootURL
+
+Type: `String`  
+Default: `/`
+
+It's useful in development mode, if you use custom `rootURL` in `config/environment.js`. By default, the SVGJar viewer is available at `http://localhost:4200/ember-svg-jar/index.html`. If you set `rootURL` to `/myapp/`, the viewer URL will change to `http://localhost:4200/myapp/ember-svg-jar/index.html`. If you use the symbol strategy, it will also prefix `outputFilepath` in the [symbols loader script](#includeloader).
+
+Example:
+
+```javascript
+let isDevelopment = EmberApp.env() === 'development';
+
+let app = new EmberApp(defaults, {
+  svgJar: {
+    rootURL: (isDevelopment && '/myapp/') || '/'
+  }
+});
+```
 
 ## Inline strategy options
 

--- a/node-tests/acceptance/viewer-builder-test.js
+++ b/node-tests/acceptance/viewer-builder-test.js
@@ -114,6 +114,7 @@ describe('ViewerBuilder', function() {
         ],
 
         links: [
+          { text: 'Configuration', url: 'https://github.com/ivanvotti/ember-svg-jar/blob/master/docs/configuration.md' },
           { text: 'Contribute', url: 'https://github.com/ivanvotti/ember-svg-jar' },
           { text: 'About', url: 'https://svgjar.firebaseapp.com' }
         ]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "broccoli-caching-writer": "^2.3.1",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
+    "broccoli-string-replace": "^0.1.2",
     "broccoli-svg-optimizer": "^1.0.1",
     "broccoli-symbolizer": "^0.5.0",
     "cheerio": "^0.20.0",

--- a/public/index.html
+++ b/public/index.html
@@ -5,16 +5,16 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>SVG Jar</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="svg-jar/config/environment" content="%7B%22modulePrefix%22%3A%22svg-jar%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22svg-jar%22%2C%22version%22%3A%220.0.1+fabd100a%22%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
+    <meta name="svg-jar/config/environment" content="%7B%22modulePrefix%22%3A%22svg-jar%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22{{ROOT_URL}}%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22svg-jar%22%2C%22version%22%3A%220.0.1+fabd100a%22%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
 
-    <script src="/ember-cli-live-reload.js" type="text/javascript"></script>
+    <script src="{{ROOT_URL}}ember-cli-live-reload.js" type="text/javascript"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600">
-    <link rel="stylesheet" href="/ember-svg-jar/assets/vendor.css">
-    <link rel="stylesheet" href="/ember-svg-jar/assets/svg-jar.css">
+    <link rel="stylesheet" href="{{ROOT_URL}}ember-svg-jar/assets/vendor.css">
+    <link rel="stylesheet" href="{{ROOT_URL}}ember-svg-jar/assets/svg-jar.css">
   </head>
 
   <body>
-    <script src="/ember-svg-jar/assets/vendor.js"></script>
-    <script src="/ember-svg-jar/assets/svg-jar.js"></script>
+    <script src="{{ROOT_URL}}ember-svg-jar/assets/vendor.js"></script>
+    <script src="{{ROOT_URL}}ember-svg-jar/assets/svg-jar.js"></script>
   </body>
 </html>

--- a/src/viewer-builder.js
+++ b/src/viewer-builder.js
@@ -142,6 +142,7 @@ function assetsToViewerModel(assets, hasManyStrategies) {
   }
 
   let links = [
+    { text: 'Configuration', url: 'https://github.com/ivanvotti/ember-svg-jar/blob/master/docs/configuration.md' },
     { text: 'Contribute', url: 'https://github.com/ivanvotti/ember-svg-jar' },
     { text: 'About', url: 'https://svgjar.firebaseapp.com' }
   ];

--- a/symbols-loader.html
+++ b/symbols-loader.html
@@ -1,8 +1,11 @@
 <script>
   var ajax = new XMLHttpRequest();
-  ajax.open('GET', '{{FILE_PATH}}', true);
+  ajax.open('GET', '{{SYMBOLS_URL}}', true);
   ajax.send();
   ajax.onload = function(e) {
+    if (this.status === 404) {
+       return;
+    }
     var div = document.createElement('div');
     div.innerHTML = ajax.responseText;
     document.body.insertBefore(div, document.body.childNodes[0]);


### PR DESCRIPTION
It's useful in development mode, if you use custom `rootURL` in `config/environment.js`.

By default, the SVGJar viewer is available at `http://localhost:4200/ember-svg-jar/index.html`. If you set `rootURL` to `/myapp/`, the viewer URL will change to `http://localhost:4200/myapp/ember-svg-jar/index.html`.

Fixes #22 and #25.