### PR TITLE
Better addon support

### DIFF
--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -16,8 +16,8 @@ export function symbolUseFor(assetId, attrs = {}) {
   return `<svg ${formatAttrs(attrs)}><use xlink:href="${assetId}" /></svg>`;
 }
 
-export function inlineSvgFor(assetId, assetStore, attrs = {}) {
-  let svg = assetStore[assetId];
+export function inlineSvgFor(assetId, loader, attrs = {}) {
+  let svg = loader(assetId);
 
   if (!svg) {
     warn(`ember-svg-jar: Missing inline SVG for ${assetId}`);
@@ -30,17 +30,17 @@ export function inlineSvgFor(assetId, assetStore, attrs = {}) {
   if (size) {
     svgAttrs.width = parseFloat(svgAttrs.width) * size || svgAttrs.width;
     svgAttrs.height = parseFloat(svgAttrs.height) * size || svgAttrs.height;
-    delete svgAttrs.size; // eslint-disable-line no-param-reassign
+    delete svgAttrs.size;
   }
 
   return `<svg ${formatAttrs(svgAttrs)}>${svg.content}</svg>`;
 }
 
-export default function makeSvg(assetId, attrs = {}, assetStore = {}) {
+export default function makeSvg(assetId, attrs = {}, loader) {
   let isSymbol = assetId.lastIndexOf('#', 0) === 0;
   let svg = isSymbol
     ? symbolUseFor(assetId, attrs)
-    : inlineSvgFor(assetId, assetStore, attrs);
+    : inlineSvgFor(assetId, loader, attrs);
 
   return htmlSafe(svg);
 }

--- a/app/helpers/svg-jar.js
+++ b/app/helpers/svg-jar.js
@@ -1,9 +1,17 @@
 import makeHelper from 'ember-svg-jar/utils/make-helper';
 import makeSVG from 'ember-svg-jar/utils/make-svg';
-import inlineAssets from '../inline-assets';
+
+function loader(assetId) {
+  try {
+    /* eslint-disable global-require */
+    return require(`ember-svg-jar/inlined/${assetId}`).default;
+  } catch (err) {
+    return null;
+  }
+}
 
 export function svgJar(assetId, svgAttrs) {
-  return makeSVG(assetId, svgAttrs, inlineAssets);
+  return makeSVG(assetId, svgAttrs, loader);
 }
 
 export default makeHelper(svgJar);

--- a/node-tests/acceptance/inline-packer-test.js
+++ b/node-tests/acceptance/inline-packer-test.js
@@ -17,24 +17,30 @@ describe('InlinePacker', function() {
 
     var node = new InlinePacker(inputNode, {
       idGen: function(filePath) { return filePath; },
-      stripPath: true,
-      outputFile: 'inline-store.js'
+      stripPath: true
     });
 
     var filesHashPromise = fixture.build(node).then(function(filesHash) {
-      expect(filesHash['inline-store.js'].indexOf('export default ')).to.equal(0);
+      expect(filesHash.inlined['foo.js'].indexOf('export default ')).to.equal(0);
 
-      filesHash['inline-store.js'] = JSON.parse(
-        filesHash['inline-store.js'].replace('export default ', '')
+      filesHash.inlined['foo.js'] = JSON.parse(
+        filesHash.inlined['foo.js'].replace('export default ', '')
+      );
+
+      expect(filesHash.inlined['bar.js'].indexOf('export default ')).to.equal(0);
+      filesHash.inlined['bar.js'] = JSON.parse(
+        filesHash.inlined['bar.js'].replace('export default ', '')
       );
 
       return filesHash;
     });
 
     return expect(filesHashPromise).to.eventually.deep.equal({
-      'inline-store.js': {
-        foo: { content: '<path d="foo"/>', attrs: { viewBox: '0 0 1 1' } },
-        bar: { content: '<path d="bar"/>', attrs: { height: '10px', viewBox: '0 0 2 2' } }
+      inlined: {
+        'foo.js':
+        { content: '<path d="foo"/>', attrs: { viewBox: '0 0 1 1' } },
+        'bar.js':
+        { content: '<path d="bar"/>', attrs: { height: '10px', viewBox: '0 0 2 2' } }
       }
     });
   });

--- a/tests/unit/utils/make-svg-test.js
+++ b/tests/unit/utils/make-svg-test.js
@@ -1,4 +1,3 @@
-import { copy } from 'ember-metal/utils';
 import { module, test } from 'qunit';
 import makeSvg, {
   formatAttrs,
@@ -17,10 +16,12 @@ test('symbolUseFor works', function(assert) {
 });
 
 test('inlineSvgFor with original attrs', function(assert) {
-  let assetStore = {
-    'with-attrs': { content: 'with-attrs content', attrs: { class: 'foo' } },
-    'no-attrs': { content: 'no-attrs content' }
-  };
+  function assetStore(id) {
+    return {
+      'with-attrs': { content: 'with-attrs content', attrs: { class: 'foo' } },
+      'no-attrs': { content: 'no-attrs content' }
+    }[id];
+  }
 
   assert.equal(
     inlineSvgFor('with-attrs', assetStore),
@@ -36,28 +37,27 @@ test('inlineSvgFor with original attrs', function(assert) {
 });
 
 test('inlineSvgFor with custom attrs', function(assert) {
-  let originalStore = {
-    icon: { content: 'icon', attrs: { class: 'original' } }
-  };
+  function assetStore(id) {
+    return {
+      icon: { content: 'icon', attrs: { class: 'original' } }
+    }[id];
+  }
 
   let customAttrs = { class: 'custom' };
-  let passedStore = copy(originalStore, true);
   assert.equal(
-    inlineSvgFor('icon', passedStore, customAttrs),
+    inlineSvgFor('icon', assetStore, customAttrs),
     '<svg class="custom">icon</svg>',
     'can rewrite original attrs'
-  );
-
-  assert.deepEqual(originalStore, passedStore,
-    'does not change the originalStore'
   );
 });
 
 test('inlineSvgFor with size attr', function(assert) {
   let customAttrs;
-  let assetStore = {
-    icon: { content: 'icon', attrs: { width: '5px', height: '10px' } }
-  };
+  function assetStore(id) {
+    return {
+      icon: { content: 'icon', attrs: { width: '5px', height: '10px' } }
+    }[id];
+  }
 
   assert.equal(
     inlineSvgFor('icon', assetStore),


### PR DESCRIPTION
This change allows ember-svg-jar to be used by addons. [Recent work](https://github.com/ivanvotti/ember-svg-jar/issues/29) also mentioned making it work in addons, but that only makes it work within an addon's own dummy app, when consumed as a `devDependency`.

This change makes ember-svg-jar work as a `dependency`. Multiple addons and/or the top-level app can all use it simultaneously without stomping each other (with the one caveat that the namespace of SVG asset ids is flat, so `{{svg-jar "something"}}` has a consistent meaning no matter where it appears, so if multiple addons try to use the same id, it's undefined which wins.

I only implemented this for the default, inline strategy. It would be possible in the future to do for the symbol strategy.