### PR TITLE
[WIP] Make symbols work with percy.io

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ module.exports = {
     return this._super.treeForAddon.call(this, mergeTreesIfNeeded(trees));
   },
 
-  contentFor(type) {
+  contentFor(type, app) {
     let includeLoader =
         this.hasSymbolStrategy() && this.optionFor('symbol', 'includeLoader');
 
@@ -103,7 +103,14 @@ module.exports = {
         this.svgJarOptions.rootURL,
         this.optionFor('symbol', 'outputFile')
       );
-      return symbolsLoaderScript.replace('{{SYMBOLS_URL}}', symbolsURL);
+
+      let symbolsSelector = app.environment === 'test' ?
+        '#ember-testing' :
+        'body';
+
+      return symbolsLoaderScript
+        .replace('{{SYMBOLS_URL}}', symbolsURL)
+        .replace('{{SYMBOLS_SELECTOR}}', symbolsSelector);
     }
 
     return '';

--- a/symbols-loader.html
+++ b/symbols-loader.html
@@ -8,6 +8,6 @@
     }
     var div = document.createElement('div');
     div.innerHTML = ajax.responseText;
-    document.body.insertBefore(div, document.body.childNodes[0]);
+    document.querySelector('{{SYMBOLS_SELECTOR}}').appendChild(div);
   };
 </script>


### PR DESCRIPTION
For the test environment move the symbols div into `#ember-testing` div
ember-percy copies the dom from `#ember-testing`
to take a snapshot of the test.

@fotinakis
