### PR TITLE
Warn when assetName is `undefined` or `null` instead of throwing error

### DIFF
--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -36,6 +36,12 @@ export function inlineSvgFor(assetId, getInlineAsset, attrs = {}) {
 }
 
 export default function makeSvg(assetId, attrs = {}, getInlineAsset) {
+  if (!assetId) {
+    // eslint-disable-next-line no-console
+    console.warn('ember-svg-jar: asset name should not be undefined or null');
+    return;
+  }
+
   let isSymbol = assetId.lastIndexOf('#', 0) === 0;
   let svg = isSymbol
     ? symbolUseFor(assetId, attrs)

--- a/tests/unit/utils/make-svg-test.js
+++ b/tests/unit/utils/make-svg-test.js
@@ -10,6 +10,10 @@ module('Unit | Utility | make svg', function() {
     assert.equal(makeSvg('#test'), '<svg ><use xlink:href="#test" /></svg>');
   });
 
+  test('makeSvg does not throw error when assetId is `undefined` or `null`', function(assert) {
+    assert.notOk(makeSvg());
+  });
+
   test('symbolUseFor works', function(assert) {
     assert.equal(symbolUseFor('#test'), '<svg ><use xlink:href="#test" /></svg>');
   });


### PR DESCRIPTION
Addresses #26.