### PR TITLE
refactor(make-svg): replace ember-copy with assign

### DIFF
--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -1,5 +1,4 @@
-import { copy } from 'ember-copy';
-import { merge } from '@ember/polyfills';
+import { assign } from '@ember/polyfills';
 import { isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/string';
 
@@ -23,7 +22,7 @@ export function inlineSvgFor(assetId, getInlineAsset, attrs = {}) {
     return;
   }
 
-  let svgAttrs = asset.attrs ? merge(copy(asset.attrs), attrs) : attrs;
+  let svgAttrs = asset.attrs ? assign({}, asset.attrs, attrs) : attrs;
   let { size } = attrs;
 
   if (size) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "broccoli-symbolizer": "^0.6.0",
     "cheerio": "^0.22.0",
     "ember-cli-babel": "^6.6.0",
-    "ember-copy": "^1.0.0",
     "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
     "path-posix": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,12 +2484,6 @@ ember-cli@~3.3.0:
     watch-detector "^0.1.0"
     yam "^0.0.24"
 
-ember-copy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
AFAICT `asset.attrs` is a shallow object and does not implement the [`Copyable` interface][1] or the `copy` method. Calling the `copy` function from ember-copy on it therefore only creates a shallow copy.

This is exactly what [`assign`][2] does, when you assign into an empty object.

Referencing #77.

[1]: https://www.emberjs.com/api/ember/release/classes/Ember.Copyable
[2]: https://emberjs.com/api/api/ember/release/functions/@ember%2Fpolyfills/assign