### PR TITLE
README - Document usage in an addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you can go IE 9+ and Android 3+, SVG is a better solution than icon fonts. Al
 - Select any SVG there and press `Enter` to copy it to the clipboard.
 - Paste it into any template and see it rendered in your browser.
 
-## Usage
+## Usage in an app
 
 Drag and drop SVG images to your project's `public` directory and copy & paste them from the <a href="http://localhost:4200/ember-svg-jar/index.html" target="_blank">assets viewer</a> to your templates.
 
@@ -90,6 +90,11 @@ By default `ember-svg-jar` looks for SVGs in the `public` directory. To get SVGs
 ```
 
 [Click here for more configuration options](#configuration)
+
+## Usage in an addon
+
+Using `ember-svg-jar` in an addon is the same as in an app, except that in the `package.json`
+of the addon, it should be listed as one of the `dependencies` and not `devDependencies`.
 
 ## Configuration
 


### PR DESCRIPTION
This PR documents how to use this addon from within another addon (such as a UI components library).

As a `devDependency`, you get an error that there is a missing inline svg.

Related to https://github.com/ivanvotti/ember-svg-jar/pull/52

P.S. thanks for your work on this addon. It is a huge help to my work!