### PR TITLE
package.json: Move development dependencies into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,10 @@
     "cheerio": "^0.22.0",
     "ember-assign-polyfill": "^2.5.0",
     "ember-cli-babel": "^7.7.3",
-    "husky": "^3.0.4",
     "json-stable-stringify": "^1.0.1",
-    "lint-staged": "^9.2.5",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
-    "path-posix": "^1.0.0",
-    "prettier": "^1.18.2"
+    "path-posix": "^1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -78,9 +75,12 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^9.1.0",
     "glob": "^7.1.4",
+    "husky": "^3.0.4",
     "in-publish": "^2.0.0",
+    "lint-staged": "^9.2.5",
     "loader.js": "^4.7.0",
     "mocha": "^6.2.0",
+    "prettier": "^1.18.2",
     "qunit-dom": "^0.9.0"
   },
   "engines": {


### PR DESCRIPTION
`husky`, `lint-staged` and `prettier` are not needed by users of this addon and are only needed when developing this addon so they should be in the `devDependencies` section.