### PR TITLE
Add accessibility options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ In this case the result can look like this:
 <svg><use xlink:href="#my-cool-icon"></use></svg>
 ```
 
+### Accessibility
+
+Pass `title`, `desc`, and `role` as properties to the helper in order to include accessible elements or attributes. `aria-labelledby` will be automatically added and point to `title` and/or `desc` if they are included.
+
+Writing this:
+
+```handlebars
+{{svg-jar "my-cool-icon" role="img" title="Icon" desc="A very cool icon"}}
+```
+
+Will create an SVG that looks like this:
+
+```handlebars
+<svg role="img" aria-labelledby="title desc">
+  <title id="title">Icon</title>
+  <desc id="desc">A very cool icon<desc>
+</svg>
+```
+
 ### Assets from Node modules
 
 By default `ember-svg-jar` looks for SVGs in the `public` directory. To get SVGs from `node_modules` packages or any other directory you will need to add them to `ember-cli-build.js` like this:

--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -28,6 +28,7 @@ export function createAccessibilityElements(attrs) {
     if (sanitizedAttrs[tag]) {
       return elements.concat(`<${tag} id="${tag}">${sanitizedAttrs[tag]}</${tag}>`);
     }
+    return elements;
   }, '');
 }
 

--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -2,15 +2,55 @@ import { assign } from '@ember/polyfills';
 import { isNone } from '@ember/utils';
 import { htmlSafe } from '@ember/template';
 
+const accessibilityElements = ['title', 'desc'];
+
+export function sanitizeAttrs(attrs) {
+  let attrsCopy = Object.assign({}, attrs);
+
+  Object.keys(attrsCopy).forEach((key) => {
+    let element = document.createElement('div');
+    element.innerText = attrsCopy[key];
+    attrsCopy[key] = element.innerHTML;
+  });
+
+  return attrsCopy;
+}
+
+export function createAccessibilityElements(attrs) {
+  const sanitizedAttrs = sanitizeAttrs(attrs);
+  const { title, desc } = sanitizedAttrs;
+
+  if (!title && !desc) {
+    return '';
+  }
+
+  return accessibilityElements.reduce((elements, tag) => {
+    if (sanitizedAttrs[tag]) {
+      return elements.concat(`<${tag} id="${tag}">${sanitizedAttrs[tag]}</${tag}>`);
+    }
+  }, '');
+}
+
+export function createAriaLabel(attrs) {
+  const { title, desc } = attrs;
+
+  if (!title && !desc) {
+    return '';
+  }
+
+  return `aria-labelledby="${accessibilityElements.filter((tag) => attrs[tag]).join(' ')}"`;
+}
+
 export function formatAttrs(attrs) {
   return Object.keys(attrs)
+    .filter((attr) => !(accessibilityElements.includes(attr)))
     .map((key) => !isNone(attrs[key]) && `${key}="${attrs[key]}"`)
     .filter((attr) => attr)
     .join(' ');
 }
 
 export function symbolUseFor(assetId, attrs = {}) {
-  return `<svg ${formatAttrs(attrs)}><use xlink:href="${assetId}" /></svg>`;
+  return `<svg ${formatAttrs(attrs)}${createAriaLabel(attrs)}><use xlink:href="${assetId}" />${createAccessibilityElements(attrs)}</svg>`;
 }
 
 export function inlineSvgFor(assetId, getInlineAsset, attrs = {}) {
@@ -31,7 +71,7 @@ export function inlineSvgFor(assetId, getInlineAsset, attrs = {}) {
     delete svgAttrs.size;
   }
 
-  return `<svg ${formatAttrs(svgAttrs)}>${asset.content}</svg>`;
+  return `<svg ${formatAttrs(svgAttrs)}${createAriaLabel(attrs)}>${createAccessibilityElements(attrs)}${asset.content}</svg>`;
 }
 
 export default function makeSvg(assetId, attrs = {}, getInlineAsset) {

--- a/tests/integration/helpers/svg-jar-test.js
+++ b/tests/integration/helpers/svg-jar-test.js
@@ -53,6 +53,17 @@ module('Integration | Helper | svg-jar', function(hooks) {
     assert.dom('svg').doesNotHaveAttribute('desc');
   });
 
+  test('it allows to set a11y SVG attributes for decorative images', async function(assert) {
+    await render(hbs`{{svg-jar "icon" role="presentation"}}`);
+    assert.dom('svg').hasAttribute('role', 'presentation');
+
+    await render(hbs`{{svg-jar "icon" role="none"}}`);
+    assert.dom('svg').hasAttribute('role', 'none');
+
+    await render(hbs`{{svg-jar "icon" aria-hidden="true"}}`);
+    assert.dom('svg').hasAttribute('aria-hidden', 'true');
+  });
+
   test('it escapes html passed into attributes', async function(assert) {
     await render(hbs`{{svg-jar "icon" title="<script>alert('evil javascript')</script>" desc="<div>evil string</div>"}}`);
 
@@ -118,6 +129,17 @@ module('Integration | Helper | svg-jar', function(hooks) {
 
     assert.dom('svg').doesNotHaveAttribute('title');
     assert.dom('svg').doesNotHaveAttribute('desc');
+  });
+
+  test('it allows to set a11y SVG attributes for decorative images for symbol strategy', async function(assert) {
+    await render(hbs`{{svg-jar "#icon" role="presentation"}}`);
+    assert.dom('svg').hasAttribute('role', 'presentation');
+
+    await render(hbs`{{svg-jar "#icon" role="none"}}`);
+    assert.dom('svg').hasAttribute('role', 'none');
+
+    await render(hbs`{{svg-jar "#icon" aria-hidden="true"}}`);
+    assert.dom('svg').hasAttribute('aria-hidden', 'true');
   });
 
   test('it escapes html passed into attributes for symbol strategy', async function(assert) {

--- a/tests/integration/helpers/svg-jar-test.js
+++ b/tests/integration/helpers/svg-jar-test.js
@@ -75,13 +75,15 @@ module('Integration | Helper | svg-jar', function(hooks) {
   });
 
   test('it allows to override original SVG attributes', async function(assert) {
-    await render(hbs`{{svg-jar "icon"}}`);
+    await render(hbs`{{svg-jar "icon" title="Green rectangle"}}`);
     assert.dom('svg').hasAttribute('viewBox', '0 0 24 24');
     assert.dom('svg').hasAttribute('height', '24');
+    assert.dom('title').hasText('Green rectangle');
 
-    await render(hbs`{{svg-jar "icon" viewBox="0 0 50 50" height="50"}}`);
+    await render(hbs`{{svg-jar "icon" viewBox="0 0 50 50" height="50" title="Red circle"}}`);
     assert.dom('svg').hasAttribute('viewBox', '0 0 50 50');
     assert.dom('svg').hasAttribute('height', '50');
+    assert.dom('title').hasText('Red circle');
   });
 
   test('it allows to remove original attributes', async function(assert) {

--- a/tests/integration/helpers/svg-jar-test.js
+++ b/tests/integration/helpers/svg-jar-test.js
@@ -31,9 +31,36 @@ module('Integration | Helper | svg-jar', function(hooks) {
   });
 
   test('it allows to set SVG attributes', async function(assert) {
-    await render(hbs`{{svg-jar "icon" class="myicon" data-foo="bar"}}`);
+    await render(hbs`{{svg-jar "icon" class="myicon" data-foo="bar" role="img"}}`);
     assert.dom('svg').hasAttribute('class', 'myicon');
     assert.dom('svg').hasAttribute('data-foo', 'bar');
+    assert.dom('svg').hasAttribute('role', 'img');
+    assert.dom('svg').doesNotHaveAttribute('aria-labelledby');
+  });
+
+  test('it adds SVG accessibility elements', async function(assert) {
+    await render(hbs`{{svg-jar "icon" class="myicon" title="Green rectangle" desc="A light green rectangle"}}`);
+    assert.dom('title').hasText('Green rectangle');
+    assert.dom('title').hasAttribute('id', 'title');
+
+    assert.dom('desc').hasText('A light green rectangle');
+    assert.dom('desc').hasAttribute('id', 'desc');
+
+    assert.dom('svg').hasAttribute('class', 'myicon');
+    assert.dom('svg').hasAttribute('aria-labelledby', 'title desc');
+
+    assert.dom('svg').doesNotHaveAttribute('title');
+    assert.dom('svg').doesNotHaveAttribute('desc');
+  });
+
+  test('it escapes html passed into attributes', async function(assert) {
+    await render(hbs`{{svg-jar "icon" title="<script>alert('evil javascript')</script>" desc="<div>evil string</div>"}}`);
+
+    assert.dom('title').hasText("<script>alert('evil javascript')</script>");
+    assert.equal(document.querySelector('#title').children.length, 0);
+
+    assert.dom('desc').hasText('<div>evil string</div>');
+    assert.equal(document.querySelector('#desc').children.length, 0);
   });
 
   test('it allows to override original SVG attributes', async function(assert) {
@@ -71,8 +98,35 @@ module('Integration | Helper | svg-jar', function(hooks) {
   });
 
   test('it allows to set SVG attributes for symbol strategy', async function(assert) {
-    await render(hbs`{{svg-jar "#icon" class="myicon" data-foo="bar"}}`);
+    await render(hbs`{{svg-jar "#icon" class="myicon" data-foo="bar" role="img"}}`);
     assert.dom('svg').hasAttribute('class', 'myicon');
     assert.dom('svg').hasAttribute('data-foo', 'bar');
+    assert.dom('svg').hasAttribute('role', 'img');
+    assert.dom('svg').doesNotHaveAttribute('aria-labelledby');
+  });
+
+  test('it adds SVG accessibility elements for symbol strategy', async function(assert) {
+    await render(hbs`{{svg-jar "#icon" class="myicon" title="Green rectangle" desc="A light green rectangle"}}`);
+    assert.dom('title').hasText('Green rectangle');
+    assert.dom('title').hasAttribute('id', 'title');
+
+    assert.dom('desc').hasText('A light green rectangle');
+    assert.dom('desc').hasAttribute('id', 'desc');
+
+    assert.dom('svg').hasAttribute('class', 'myicon');
+    assert.dom('svg').hasAttribute('aria-labelledby', 'title desc');
+
+    assert.dom('svg').doesNotHaveAttribute('title');
+    assert.dom('svg').doesNotHaveAttribute('desc');
+  });
+
+  test('it escapes html passed into attributes for symbol strategy', async function(assert) {
+    await render(hbs`{{svg-jar "#icon" title="<script>alert('evil javascript')</script>" desc="<div>evil string</div>"}}`);
+
+    assert.dom('title').hasText("<script>alert('evil javascript')</script>");
+    assert.equal(document.querySelector('#title').children.length, 0);
+
+    assert.dom('desc').hasText('<div>evil string</div>');
+    assert.equal(document.querySelector('#desc').children.length, 0);
   });
 });

--- a/tests/unit/utils/make-svg-test.js
+++ b/tests/unit/utils/make-svg-test.js
@@ -116,6 +116,13 @@ module('Unit | Utility | make svg', function() {
     assert.equal(result, '<title id="title">Title</title><desc id="desc">This is the title</desc>');
   });
 
+  test('createAccessibilityElements works with just one element', function(assert) {
+    let result = createAccessibilityElements({
+      title: 'Title',
+    });
+    assert.equal(result, '<title id="title">Title</title>');
+  });
+
   test('sanitizeAttrs works', function(assert) {
     let result = sanitizeAttrs({
       title: '<script>Title</script>',

--- a/tests/unit/utils/make-svg-test.js
+++ b/tests/unit/utils/make-svg-test.js
@@ -2,7 +2,10 @@ import { module, test } from 'qunit';
 import makeSvg, {
   formatAttrs,
   inlineSvgFor,
-  symbolUseFor
+  symbolUseFor,
+  createAriaLabel,
+  createAccessibilityElements,
+  sanitizeAttrs
 } from 'ember-svg-jar/utils/make-svg';
 
 module('Unit | Utility | make svg', function() {
@@ -88,8 +91,39 @@ module('Unit | Utility | make svg', function() {
       attrName: 'attrValue',
       'f:oo': 'bar',
       isnull: null,
-      isundefined: undefined
+      isundefined: undefined,
+      title: 'Title'
     });
     assert.equal(result, 'attrName="attrValue" f:oo="bar"');
+  });
+
+  test('createAriaLabel works', function(assert) {
+    let result = createAriaLabel({
+      title: 'Title',
+      desc: 'This is the title'
+    });
+    assert.equal(result, 'aria-labelledby="title desc"');
+
+    result = createAriaLabel({});
+    assert.equal(result, '');
+  });
+
+  test('createAccessibilityElements works', function(assert) {
+    let result = createAccessibilityElements({
+      title: 'Title',
+      desc: 'This is the title'
+    });
+    assert.equal(result, '<title id="title">Title</title><desc id="desc">This is the title</desc>');
+  });
+
+  test('sanitizeAttrs works', function(assert) {
+    let result = sanitizeAttrs({
+      title: '<script>Title</script>',
+      desc: '<div>This is the title</div>'
+    });
+    assert.deepEqual(result, {
+      title: '&lt;script&gt;Title&lt;/script&gt;',
+      desc: '&lt;div&gt;This is the title&lt;/div&gt;'
+    });
   });
 });


### PR DESCRIPTION
Add `title` and `desc` elements to SVGs if these properties are passed to `svg-jar`. The `aria-labelledby` attribute will be added and point to either or both of these elements if they are passed in. This approach also accepts translations.
Fixes #43 