### PR TITLE
Add `validations.throwOnFailure` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ let app = new EmberApp(defaults, {
 #### validations
 
 Type: `Object`  
-Default: `{ validateViewBox: true, checkForDuplicates: true }`
+Default: `{ throwOnFailure: false, validateViewBox: true, checkForDuplicates: true }`
 
 By default SVGJar checks your assets with some validations and emits warning
 messages if it finds any problems. You can suppress the warnings by setting
@@ -191,6 +191,9 @@ particular validations to `false`.
 
 `checkForDuplicates` -- It shows all assets with not unique asset IDs. Asset IDs
 must be unique to embed SVGs correctly.
+
+You can also set `throwOnFailure` to `true` if you would prefer for the build
+to fail if a validation was unsuccessful.
 
 Example (we only disable `validateViewBox` here):
 

--- a/lib/build-options.js
+++ b/lib/build-options.js
@@ -67,6 +67,7 @@ function buildOptions(app) {
     persist: true,
 
     validations: {
+      throwOnFailure: false,
       validateViewBox: true,
       checkForDuplicates: true
     },

--- a/lib/validate-assets.js
+++ b/lib/validate-assets.js
@@ -48,7 +48,12 @@ module.exports = function validateAssets(items, validationConfig = {}, strategy)
     let message = validate(items);
 
     if (message) {
-      consoleUI.warn(`${strategy} ${message}`);
+      let warning = `${strategy} ${message}`;
+      if (validationConfig.throwOnFailure) {
+        throw new Error(warning);
+      } else {
+        consoleUI.warn(warning);
+      }
     }
   });
 };

--- a/node-tests/unit/build-options-test.js
+++ b/node-tests/unit/build-options-test.js
@@ -31,6 +31,7 @@ const defaultsFixture = Object.freeze({
   persist: true,
 
   validations: {
+    throwOnFailure: false,
     validateViewBox: true,
     checkForDuplicates: true
   },


### PR DESCRIPTION
We would like our build to fail on CI when an SVG without a `viewBox` is submitted. This new option allows us to throw an error instead of printing the console warning.

/cc @ivanvotti 