### PR TITLE
Keep validation warnings on stderr

### DIFF
--- a/lib/console-ui.js
+++ b/lib/console-ui.js
@@ -4,7 +4,7 @@ const UI = require('console-ui');
 
 const ui = new UI({
   inputStream: process.stdin,
-  outputStream: process.stdout,
+  outputStream: process.stderr,
   errorStream: process.stderr
 });
 


### PR DESCRIPTION
This ensures that all validation warnings are emitted on stderr and not stdout.

Using stdout makes it impossible to write a command that emits formatted output. For example, `embroider-compat-audit --json > results.json` is supposed to dump a json summary of whether your app has any embroider compatibility problems. But right now, those results get ember-svg-jar warnings mixed into the json, breaking the formatting.

`console-ui` has weird opinions about stderr vs stdout. It seems to think that things at log level `ERROR` go on stderr, but things on log level `WARNING` go on stdout. This is backwards, because warnings shouldn't disrupt the normal program output, while *maybe* sometimes error should.

In the case of ember-svg-jar, I don't see any reason to ever use stdout, so we can just tell console-ui to always use stderr for everything.