### PR TITLE
Make HTML sanitization Node.js/FastBoot compatible

### DIFF
--- a/addon/utils/make-svg.js
+++ b/addon/utils/make-svg.js
@@ -4,13 +4,38 @@ import { htmlSafe } from '@ember/template';
 
 const accessibilityElements = ['title', 'desc'];
 
+const ESC = {
+  '"': '&quot;',
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;'
+};
+
+function matcher(char) {
+  return ESC[char];
+}
+
+function escapeText(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+
+  if (text.indexOf('>') > -1
+    || text.indexOf('<') > -1
+    || text.indexOf('&') > -1
+    || text.indexOf('"') > -1
+  ) {
+    return text.replace(/[&"<>]/g, matcher);
+  }
+
+  return text;
+}
+
 export function sanitizeAttrs(attrs) {
   let attrsCopy = Object.assign({}, attrs);
 
   Object.keys(attrsCopy).forEach((key) => {
-    let element = document.createElement('div');
-    element.innerText = attrsCopy[key];
-    attrsCopy[key] = element.innerHTML;
+    attrsCopy[key] = escapeText(attrsCopy[key]);
   });
 
   return attrsCopy;


### PR DESCRIPTION
Replace `document.createElement('div').innerText` with
the same approach Ember FastBoot is using in `@simple-dom/serializer`.

[Reference](https://github.com/ember-fastboot/simple-dom/blob/923c0198576134a16e34f7e4cf68e35243afa945/packages/%40simple-dom/serializer/src/index.ts#L56-L62)

Fixes #178