### PR TITLE
Fix the vulnerabiltiy issue discussed in #197

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "broccoli-plugin": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",
     "broccoli-svg-optimizer": "2.0.0",
-    "cheerio": "^0.22.0",
+    "cheerio": "^1.0.0-rc.4",
     "console-ui": "^3.1.1",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",


### PR DESCRIPTION
Hi, @jherdman, this PR can fix the vulnerabiltiy issue we have discussed in #197. 
It can update `cheerio ^0.22.0 ➔ ^1.0.0-rc.4` to remove the  vulnerability [**CVE-2021-33587**](https://snyk.io/vuln/SNYK-JS-CSSWHAT-1298035) introduced by **css-what**, since **cheerio@1.0.0-rc.4**(>=1.0.0-rc.4) doesn’t depends on **css-what** any more.
It would be better if **ember-svg-jar@2.3.\*** can fix this issue and release a patched version **ember-svg-jar@2.3.4** to npm.Then this vulnerbility patch can be automatically propagated into a large amount of downstream projects :)
Please check it.
Thanks again.